### PR TITLE
Feature/wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If some environment variables are existed (allow load `/app/.env` file is found)
 | `LARAVEL_ECHO_SERVER_HOST` | `host` | |
 | `LARAVEL_ECHO_SERVER_PORT` | `port` | |
 | `LARAVEL_ECHO_SERVER_DEBUG` | `devMode` | |
+| `LARAVEL_ECHO_SERVER_WAIT` | `true` | Wait for `/app/laravel-echo-server.json` to be injected by another process. Default is `false`. |
 
 See more about `laravel-echo-server.json` in [here](https://github.com/tlaverdure/laravel-echo-server/blob/master/README.md)
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,14 @@ fi
 
 # laravel-echo-server <sub-command>
 if [ "$1" = 'start' ] || [ "$1" = 'client:add' ] || [ "$1" = 'client:remove' ]; then
-    if [ ! -f /app/laravel-echo-server.json ]; then
+    if [ "${LARAVEL_ECHO_SERVER_WAIT:-false}" == "true" ]; then
+        # wait for another process to inject the config
+        echo -n "Waiting for /app/laravel-echo-server.json"
+        while [ ! -f /app/laravel-echo-server.json ]; do
+            sleep 2
+            echo -n "."
+        done
+    elif [ ! -f /app/laravel-echo-server.json ]; then
         cp /etc/laravel-echo-server.json /app/laravel-echo-server.json
         # Replace with environment variables
         sed -i "s|LARAVEL_ECHO_SERVER_DB|${LARAVEL_ECHO_SERVER_DB:-redis}|i" /app/laravel-echo-server.json


### PR DESCRIPTION
Some workflows may need a little bit of time if `/app/laravel-echo-server.json` is being sourced externally/injected by another container.

By setting `LARAVEL_ECHO_SERVER_WAIT` to `true` we can instruct the entrypoint.sh to wait for the file to be injected rather than attempt to build it from environment variables.