### PR TITLE
Adds support for redis key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Using database be configured by environment variable `LARAVEL_ECHO_SERVER_DB` (d
     "redis": {
       "host": "REDIS_HOST",
       "port": "REDIS_PORT",
+      "keyPrefix": "REDIS_KEY_PREFIX",
       "options": {
         "db": "REDIS_DB_BACKEND"
       }
@@ -72,11 +73,12 @@ Using database be configured by environment variable `LARAVEL_ECHO_SERVER_DB` (d
   },
   ```
 
-  | Environment variable | Default value |
-  |:---------------------|:--------------|
-  | `REDIS_HOST`         | `redis`       |
-  | `REDIS_PORT`         | `6379`        |
-  | `REDIS_DB_BACKEND`   | `0`           |
+  | Environment variable | Default value       |
+  |:---------------------|:--------------------|
+  | `REDIS_HOST`         | `redis`             |
+  | `REDIS_PORT`         | `6379`              |
+  | `REDIS_KEY_PREFIX`   | `laravel_database_` |
+  | `REDIS_DB_BACKEND`   | `0`                 |
 
 - You can use SQLite database by set environment variable `LARAVEL_ECHO_SERVER_DB` to `sqlite`. 
   The SQLite file will store in `/app/database/`

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -21,6 +21,7 @@ if [[ "$1" == 'start' ]] || [[ "$1" == 'client:add' ]] || [[ "$1" == 'client:rem
         sed -i "s|LARAVEL_ECHO_SERVER_DB|${LARAVEL_ECHO_SERVER_DB:-redis}|i" /app/laravel-echo-server.json
         sed -i "s|REDIS_HOST|${REDIS_HOST:-redis}|i" /app/laravel-echo-server.json
         sed -i "s|REDIS_PORT|${REDIS_PORT:-6379}|i" /app/laravel-echo-server.json
+        sed -i "s|REDIS_KEY_PREFIX|${REDIS_KEY_PREFIX:-laravel_database_}|i" /app/laravel-echo-server.json
         sed -i "s|REDIS_DB_BACKEND|${REDIS_DB_BACKEND:-0}|i" /app/laravel-echo-server.json
     fi
     set -- laravel-echo-server "$@"

--- a/src/laravel-echo-server.json
+++ b/src/laravel-echo-server.json
@@ -7,6 +7,7 @@
     "redis": {
       "host": "REDIS_HOST",
       "port": "REDIS_PORT",
+      "keyPrefix": "REDIS_KEY_PREFIX",
       "options": {
         "db": "REDIS_DB_BACKEND"
       }


### PR DESCRIPTION
This PR adds support for the keyPrefix option, which was added in [laravel-echo-server 1.6.0](https://github.com/tlaverdure/laravel-echo-server/releases/tag/1.6.0).

See:
- https://github.com/laravel/framework/issues/28701
- https://github.com/tlaverdure/laravel-echo-server/releases/tag/1.6.0